### PR TITLE
Fix propagation nan's upon bias initialization

### DIFF
--- a/convNd.py
+++ b/convNd.py
@@ -77,7 +77,7 @@ class convNd(nn.Module):
         self.groups = groups
         self.use_bias = use_bias
         if use_bias:
-            self.bias = nn.Parameter(torch.Tensor(out_channels))
+            self.bias = nn.Parameter(torch.zeros(out_channels))
         else:
             self.register_parameter('bias', None)
         self.bias_initializer = bias_initializer


### PR DESCRIPTION
This is just a simple proposal to fix the issue of `nan`s propagating from the bias initialization.  For my use case, using zeros is sufficient, but there might be other (better) options than this one.